### PR TITLE
Add byte size limit for committedLog list

### DIFF
--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/ZkDatabaseCorruptionTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/ZkDatabaseCorruptionTest.java
@@ -24,12 +24,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZKTestCase;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.server.Request;
 import org.apache.zookeeper.server.SyncRequestProcessor;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
@@ -196,4 +198,13 @@ public class ZkDatabaseCorruptionTest extends ZKTestCase {
         assertEquals(0, zkDatabase.calculateTxnLogSizeLimit());
     }
 
+    @Test
+    public void testCommittedLogSizeLimit() throws IOException {
+        ZKDatabase zkDatabase = new ZKDatabase(new FileTxnSnapLog(new File("foo"), new File("bar")));
+        final int byteSize = 1024;
+        ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[byteSize]);
+        Request request = new Request(null, 0, 0, ZooDefs.OpCode.setData, byteBuffer, null);
+        zkDatabase.addCommittedProposal(request);
+        assertEquals(byteSize, zkDatabase.getCurrentCommitLogSize());
+    }
 }


### PR DESCRIPTION
### Motivation
Current committedLog list in ZKDatabase is just limited by length with 500. However, it one item's size goes to 27MB, the total size  of the committedLog list will be `27MB * 500 = 13.5GB`. It will occupies too much heap memory and cause JVM GC frequently and even led to heap OOM error.

In this PR, we want to import the bytes size limit for the committedLog list.

### Modification
1. Add bytes size limit for the committedLog list.